### PR TITLE
Tool quantity depletion upon crafting

### DIFF
--- a/IAT/Core/IAT_CraftingPlus/scripts/4_world/actions/iat_actioncraftonworkbench.c
+++ b/IAT/Core/IAT_CraftingPlus/scripts/4_world/actions/iat_actioncraftonworkbench.c
@@ -69,6 +69,22 @@ class IAT_ActionCraftOnWorkbench extends ActionContinuousBase
       // because players are fucking huge ass babies
 			// craftingWorkbench.DecreaseHealth( craftingWorkbench.GetCraftingDamage(), false );
       // Print(string.Format("Creating %1 from inded %2",newItem.GetDisplayName(), variantId));
+
+
+      // check against tool type (if has quant) & deplete tool quant each time when crafting
+      ItemBase tool = action_data.m_MainItem;
+      if (tool && tool.HasQuantity())
+      {
+        int quantityToReduce = 1; // adjust as needed
+        tool.AddQuantity(-quantityToReduce);
+
+        // deleting tool if quant reaches zero
+        if (tool.GetQuantity() <= 0)
+        {
+          tool.DeleteSafe();
+        }
+      }
+	    
       Object newObject = GetGame().CreateObjectEx(newItem.GetItemClassName(), craftingWorkbench.GetMemoryPointPosition("item_spawn_position"), ECE_SETUP|ECE_NOSURFACEALIGN|ECE_KEEPHEIGHT|ECE_NOLIFETIME|ECE_DYNAMIC_PERSISTENCY);
       if (newItem.GetItemQuantity() > 1)
       {


### PR DESCRIPTION
#### adds logic for checking against tool type used when crafting:
- if tool has quantity values;
- if so, depletes by 1 unit each use while crafting;
- if quant reaches 0 -- `DeleteSafe`.